### PR TITLE
fix build on Ubuntu 19.04 (which was warning about catching an except…

### DIFF
--- a/src/chBenchmark.cc
+++ b/src/chBenchmark.cc
@@ -195,7 +195,7 @@ static void* transactionalThread(void* args) {
 static int parseInt(const char* context, const char* v) {
     try {
         return std::stoi(optarg);
-    } catch (std::exception) {
+    } catch (const std::exception&) {
         errx(1, "unable to parse integer %s for %s\n", v, context);
     }
 }


### PR DESCRIPTION
…ion by value)