### PR TITLE
Enable the '-l' parameter

### DIFF
--- a/src/chBenchmark.cc
+++ b/src/chBenchmark.cc
@@ -361,7 +361,7 @@ static int run(int argc, char* argv[]) {
     const char* logFile = nullptr;
     bool createSources = false;
     std::vector<std::string> mzViews;
-    while ((c = getopt_long(argc, argv, "d:u:p:a:t:w:r:g:o:", longOpts,
+    while ((c = getopt_long(argc, argv, "d:u:p:a:t:w:r:g:o:l:", longOpts,
                             nullptr)) != -1) {
         switch (c) {
         case 'd':


### PR DESCRIPTION
For some reason, the [plumbing for the log files](https://github.com/MaterializeInc/chbenchmark/blob/master/src/chBenchmark.cc#L337) exists, but the [call to getopt_long](https://github.com/MaterializeInc/chbenchmark/blob/master/src/chBenchmark.cc#L364) doesn't make the log file parameter accessible. I've tested this, and it enables a whole new world of logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/materializeinc/chbenchmark/6)
<!-- Reviewable:end -->
