### PR TITLE
Change createAllSources to return all sources that match the like string

### DIFF
--- a/src/materialized.cc
+++ b/src/materialized.cc
@@ -25,7 +25,8 @@ mz::createAllSources(pqxx::connection &c, std::string from, std::string registry
     from = c.quote(from);
     registry = c.quote(registry);
     auto realLike = c.quote(like ? like.value() : std::string("%"));
-    auto pqResult = w.exec("CREATE SOURCES LIKE " + realLike + " FROM " + from + " USING SCHEMA REGISTRY " + registry);
+    w.exec("CREATE SOURCES LIKE " + realLike + " FROM " + from + " USING SCHEMA REGISTRY " + registry);
+    auto pqResult = w.exec("SHOW SOURCES LIKE " + realLike);
     auto cols = pqResult.columns();
     if (cols != 1) {
         throw UnexpectedCreateSourcesResult {"Wrong number of columns: " + std::to_string(cols)};


### PR DESCRIPTION
It no longer returns just the sources that were created. Since we're using it
to assert that all the sources that we want are _present_, this is closer to
the desired behavior.