### PR TITLE
Fix CMake build on macOS

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 *
 !CMakeLists.txt
+!cmake
 !src
 !flush-tables
 !mz-default.cfg

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,31 +1,46 @@
 cmake_minimum_required(VERSION 3.5)
 project(chbenchmark)
 
-set(CMAKE_CXX_STANDARD 17)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
-include_directories(src)
-include_directories(src/dialect)
+find_package(Threads REQUIRED)
+find_package(ODBC REQUIRED)
+find_package(PostgreSQL REQUIRED)
+find_package(Pqxx REQUIRED)
+find_package(Config++ REQUIRED)
 
 add_executable(chbenchmark
-        src/dialect/DialectStrategy.cc
-        src/AnalyticalStatistic.cc
-        src/chBenchmark.cc
-        src/DataSource.cc
-        src/DbcTools.cc
-        src/Log.cc
-        src/PthreadShim.cc
-        src/Queries.cc
-        src/Random.cc
-        src/Schema.cc
-        src/TransactionalStatistic.cc
-        src/Transactions.cc
-        src/TupleGen.cc
-        src/materialized.cc
-        src/mz-config.cpp src/Histogram.cc src/Histogram.h src/Config.cc)
+    src/AnalyticalStatistic.cc
+    src/chBenchmark.cc
+    src/Config.cc
+    src/DataSource.cc
+    src/DbcTools.cc
+    src/dialect/DialectStrategy.cc
+    src/Histogram.cc
+    src/Histogram.h
+    src/Log.cc
+    src/materialized.cc
+    src/mz-config.cpp
+    src/PthreadShim.cc
+    src/Queries.cc
+    src/Random.cc
+    src/Schema.cc
+    src/TransactionalStatistic.cc
+    src/Transactions.cc
+    src/TupleGen.cc)
+
+target_compile_features(chbenchmark PRIVATE cxx_std_17)
+
+target_include_directories(chbenchmark PRIVATE
+    src
+    src/dialect
+    ${PostgreSQL_INCLUDE_DIRS}
+    ${Pqxx_INCLUDE_DIRS}
+    ${Config++_INCLUDE_DIRS})
 
 target_link_libraries(chbenchmark
-        odbc
-        pthread
-        pq
-        pqxx
-        config++)
+    Threads::Threads
+    ODBC::ODBC
+    ${PostgreSQL_LIBRARIES}
+    ${Pqxx_LIBRARIES}
+    ${Config++_LIBRARIES})

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:disco
 
-RUN apt-get update && apt-get install -qy build-essential unixodbc-dev cmake libpqxx-dev libconfig++-dev
+RUN apt-get update && apt-get install -qy build-essential unixodbc-dev cmake libpqxx-dev libconfig++-dev postgresql-server-dev-11
 
 COPY . workdir/
 RUN mkdir workdir/build && cd workdir/build && cmake -DCMAKE_BUILD_TYPE=Release .. && make

--- a/cmake/FindConfig++.cmake
+++ b/cmake/FindConfig++.cmake
@@ -1,0 +1,20 @@
+include(FindPackageHandleStandardArgs)
+
+find_package(PkgConfig)
+pkg_check_modules(PC_Config++ QUIET libconfig++)
+
+find_path(Config++_INCLUDE_DIR
+    NAME libconfig.h++
+    PATHS /usr/include /usr/local/include ${PC_Config++_INCLUDE_DIRS})
+
+find_library(Config++_LIBRARY NAMES config++ PATHS ${PC_Config++_LIBRARY_DIRS})
+
+find_package_handle_standard_args(Config++ DEFAULT_MSG Config++_LIBRARY Config++_INCLUDE_DIR)
+
+if(Config++_FOUND)
+  set(Config++_LIBRARIES ${Config++_LIBRARY})
+  set(Config++_INCLUDE_DIRS ${Config++_INCLUDE_DIR})
+  set(Config++_DEFINITIONS ${PC_Config++_CFLAGS_OTHER})
+endif()
+
+mark_as_advanced(Config++_INCLUDE_DIR Config++_LIBRARY)

--- a/cmake/FindPqxx.cmake
+++ b/cmake/FindPqxx.cmake
@@ -1,0 +1,20 @@
+include(FindPackageHandleStandardArgs)
+
+find_package(PkgConfig)
+pkg_check_modules(PC_Pqxx QUIET libpqxx)
+
+find_path(Pqxx_INCLUDE_DIR
+    NAME pqxx
+    PATHS /usr/include /usr/local/include ${PC_Pqxx_INCLUDE_DIRS})
+
+find_library(Pqxx_LIBRARY NAMES pqxx PATHS ${PC_Pqxx_LIBRARY_DIRS})
+
+find_package_handle_standard_args(Pqxx DEFAULT_MSG Pqxx_LIBRARY Pqxx_INCLUDE_DIR)
+
+if(Pqxx_FOUND)
+  set(Pqxx_LIBRARIES ${Pqxx_LIBRARY})
+  set(Pqxx_INCLUDE_DIRS ${Pqxx_INCLUDE_DIR})
+  set(Pqxx_DEFINITIONS ${PC_Pqxx_CFLAGS_OTHER})
+endif()
+
+mark_as_advanced(Pqxx_INCLUDE_DIR Pqxx_LIBRARY)


### PR DESCRIPTION
Just linking against dependencies is insufficient. Instead, use CMake's
find_package system, which will hunt down dependencies in a variety of
platform-specific places. CMake doesn't ship find modules for Pqxx or
Config++, so we include our own versions.